### PR TITLE
fix oneOf serialization/deserialization (issue #37)

### DIFF
--- a/Falanx.Ast/ProvidedTypesExtensions.fs
+++ b/Falanx.Ast/ProvidedTypesExtensions.fs
@@ -49,7 +49,7 @@ type ProvidedUnion(isTgt: bool, container:TypeContainer, className: string, getB
     override __.GetCustomAttributes(_attributeType, _inherit) = unionAttribs
         
     //fields is set to just one for now
-    member __.AddUnionCase(tag: int, position: int, name: string, [field]: PropertyInfo list) =
+    member this.AddUnionCase(tag: int, position: int, name: string, [field]: PropertyInfo list) =
 
         //Add tag to the `Tags` nested class
         tagsType.AddMember(ProvidedField.Literal(name, typeof<int>, tag))
@@ -59,7 +59,7 @@ type ProvidedUnion(isTgt: bool, container:TypeContainer, className: string, getB
         let unionTag = ProvidedProperty("Tag", typeof<int>, getterCode = fun _ -> Microsoft.FSharp.Quotations.Expr.Value tag)
         let fieldProp =
             let fp = field
-            let fieldProp = ProvidedProperty("Item", fp.PropertyType, getterCode = fun _ -> Unchecked.defaultof<_>)
+            let fieldProp = ProvidedProperty(fp.Name, fp.PropertyType, getterCode = fun _ -> Unchecked.defaultof<_>)
             //[CompilationMapping(SourceConstructFlags.Field, 0, 0)]
             let compilationAttributeType = typeof<CompilationMappingAttribute>
             let constructor = compilationAttributeType.TryGetConstructor([|typeof<SourceConstructFlags>; typeof<int>; typeof<int> |])
@@ -77,12 +77,12 @@ type ProvidedUnion(isTgt: bool, container:TypeContainer, className: string, getB
             
         unionCaseType.AddMember unionTag
         unionCaseType.AddMember fieldProp
-        __.AddMember unionCaseType           
+        this.AddMember unionCaseType           
         
         unionCases.Add { tag = tag
                          position = position
                          name = name
-                         declaringType = __
+                         declaringType = this
                          fields = [field]
                          unionCaseType = unionCaseType }
         

--- a/Falanx.Ast/ProvidedTypesExtensions.fs
+++ b/Falanx.Ast/ProvidedTypesExtensions.fs
@@ -49,7 +49,7 @@ type ProvidedUnion(isTgt: bool, container:TypeContainer, className: string, getB
     override __.GetCustomAttributes(_attributeType, _inherit) = unionAttribs
         
     //fields is set to just one for now
-    member this.AddUnionCase(tag: int, position: int, name: string, [field]: PropertyInfo list) =
+    member __.AddUnionCase(tag: int, position: int, name: string, [field]: PropertyInfo list) =
 
         //Add tag to the `Tags` nested class
         tagsType.AddMember(ProvidedField.Literal(name, typeof<int>, tag))

--- a/Falanx.BinaryGenerator/Deserialization.fs
+++ b/Falanx.BinaryGenerator/Deserialization.fs
@@ -95,7 +95,7 @@ module Deserialization =
         let value = deserializeField propertyDescriptor field
         Expr.PropertySet(this, propertyDescriptor.ProvidedProperty, <@@  Some value @@>)
         
-    let private handleOptionalUnion (this: Expr) (propertyDescriptor: PropertyDescriptor) (providedUnion: ProvidedUnion) (field: Expr) =
+    let private handleOptionalUnion (this: Expr) (unionProp : ProvidedProperty) (propertyDescriptor: PropertyDescriptor) (providedUnion: ProvidedUnion) (field: Expr) =
         let value = deserializeField propertyDescriptor field
         //create a union constructor and feed the deserialised field into it
         let names (number:int) : string =
@@ -106,7 +106,12 @@ module Deserialization =
         | Some puc ->
             let unionCaseInfo = mkUnionCaseInfo puc.declaringType puc.tag names
             let unionCtor = Expr.NewUnionCaseUnchecked(unionCaseInfo, [value] )
-            Expr.PropertySetUnchecked(this, propertyDescriptor.ProvidedProperty, unionCtor)
+            let wrappedAsOption = 
+                let uinfo = 
+                    FSharp.Reflection.FSharpType.GetUnionCases(TypeSymbol(TypeSymbolKind.OtherGeneric(typedefof<option<_>>),[|providedUnion|])) 
+                    |> Seq.find (fun x -> x.Name = "Some")
+                Expr.NewUnionCase(uinfo,[unionCtor])
+            Expr.PropertySetUnchecked(this, unionProp, wrappedAsOption)
         | None -> failwithf "Unable to find union case by position: %i for %s"  propertyDescriptor.Position providedUnion.Name
         
     let private handleRepeated this propertyDescriptor field =
@@ -140,7 +145,7 @@ module Deserialization =
                 let oneOfHandlers = 
                     typeInfo.OneOfGroups
                     |> Seq.map (fun descriptor -> descriptor.Properties
-                                                  |> Seq.map (fun (KeyValue(_, prop)) -> prop.Position, handleOptionalUnion this prop descriptor.OneOfType))
+                                                  |> Seq.map (fun (KeyValue(_, prop)) -> prop.Position, handleOptionalUnion this descriptor.CaseProperty prop descriptor.OneOfType))
                     |> Seq.concat
                     
                 //create map handlers


### PR DESCRIPTION
Seems the serialization/deserialization methods for unions had issues in general.  For example
```proto
message Command {
  oneof sub {
    int32 poll = 1;
    int32 discover = 2;
  }
}
```
would generate
```fsharp
namespace test

open System
open Froto.Serialization
open System.Collections.Generic
open Falanx.BinaryCodec
open Falanx.BinaryCodec.Primitives

module Command =
    type sub =
        | Poll of Poll : int
        | Discover of Discover : int

[<CLIMutable>]
type Command =
    { mutable sub : Command.sub option }

    static member Serialize(m : Command, buffer : ZeroCopyBuffer) =
        if match m.sub with
           | Some _ -> true
           | _ -> false
        then
            if match Option.get<Command.sub> (m.sub) with
               | Command.sub.Discover _ -> true
               | _ -> false
            then Primitives.writeInt32 2 buffer (Option.get<Command.sub>(m.sub).Item)
            else if match Option.get<Command.sub> (m.sub) with
                    | Command.sub.Poll _ -> true
                    | _ -> false
            then Primitives.writeInt32 1 buffer (Option.get<Command.sub>(m.sub).Item)
            else ()
        else ()

    static member Deserialize(buffer : ZeroCopyBuffer) = Primitives.deserialize<Command> (buffer)
    interface IMessage with
        member x.Serialize(buffer : ZeroCopyBuffer) = Command.Serialize(x, buffer)

        member x.ReadFrom(buffer : ZeroCopyBuffer) =
            let enumerator : IEnumerator<Froto.Serialization.Encoding.RawField> =
                ZeroCopyBuffer.allFields(buffer).GetEnumerator()
            while enumerator.MoveNext() do
                let current : Froto.Serialization.Encoding.RawField = enumerator.Current
                if current.FieldNum = 2 then x.Discover <- Command.sub.Discover(Primitives.readInt32 current)
                else if current.FieldNum = 1 then x.Poll <- Command.sub.Poll(Primitives.readInt32 current)
                else ()
            enumerator.Dispose()

        member x.SerializedLength() = Primitives.serializedLength<Command> (x)
```

Problems: 
* Command.sub.Discover _ (and alike) when pattern matching should be Command.Discover _ otherwise there's a compile error
* x.Poll <- Command.sub.Poll(Primitives.readInt32 current) should be x.sub <- Some(...)
* (Option.get<Command.sub>(m.sub).Item) is invalid

This also fixes issue #37 so using that example with the updates:

```proto
message Poll {
}

message Discover {
}

message Command {
  oneof sub {
    Poll poll = 1;
    Discover discover = 2;
  }
}
```

```fsharp
open System
open Froto.Serialization
open System.Collections.Generic
open Falanx.BinaryCodec
open Falanx.BinaryCodec.Primitives

[<CLIMutable>]
type Poll =
    {  }
    static member Serialize(m : Poll, buffer : ZeroCopyBuffer) = ()
    static member Deserialize(buffer : ZeroCopyBuffer) = Primitives.deserialize<Poll> (buffer)
    interface IMessage with
        member x.Serialize(buffer : ZeroCopyBuffer) = Poll.Serialize(x, buffer)

        member x.ReadFrom(buffer : ZeroCopyBuffer) =
            let enumerator : IEnumerator<Froto.Serialization.Encoding.RawField> =
                ZeroCopyBuffer.allFields(buffer).GetEnumerator()
            while enumerator.MoveNext() do
                let current : Froto.Serialization.Encoding.RawField = enumerator.Current
                ()
            enumerator.Dispose()

        member x.SerializedLength() = Primitives.serializedLength<Poll> (x)

[<CLIMutable>]
type Discover =
    {  }
    static member Serialize(m : Discover, buffer : ZeroCopyBuffer) = ()
    static member Deserialize(buffer : ZeroCopyBuffer) = Primitives.deserialize<Discover> (buffer)
    interface IMessage with
        member x.Serialize(buffer : ZeroCopyBuffer) = Discover.Serialize(x, buffer)

        member x.ReadFrom(buffer : ZeroCopyBuffer) =
            let enumerator : IEnumerator<Froto.Serialization.Encoding.RawField> =
                ZeroCopyBuffer.allFields(buffer).GetEnumerator()
            while enumerator.MoveNext() do
                let current : Froto.Serialization.Encoding.RawField = enumerator.Current
                ()
            enumerator.Dispose()

        member x.SerializedLength() = Primitives.serializedLength<Discover> (x)

module Command =
    type sub =
        | Poll of Poll : Poll
        | Discover of Discover : Discover

[<CLIMutable>]
type Command =
    { mutable sub : Command.sub option }

    static member Serialize(m : Command, buffer : ZeroCopyBuffer) =
        if match m.sub with
           | Some _ -> true
           | _ -> false
        then
            if match Option.get<Command.sub> (m.sub) with
               | Command.Discover _ -> true
               | _ -> false
            then
                Primitives.writeEmbedded (2) (buffer) (match Option.get<Command.sub> (m.sub) with
                                                       | Command.Discover(Discover = x) -> x
                                                       | _ -> failwith "Should never hit")
            else if match Option.get<Command.sub> (m.sub) with
                    | Command.Poll _ -> true
                    | _ -> false
            then
                Primitives.writeEmbedded (1) (buffer) (match Option.get<Command.sub> (m.sub) with
                                                       | Command.Poll(Poll = x) -> x
                                                       | _ -> failwith "Should never hit")
            else ()
        else ()

    static member Deserialize(buffer : ZeroCopyBuffer) = Primitives.deserialize<Command> (buffer)
    interface IMessage with
        member x.Serialize(buffer : ZeroCopyBuffer) = Command.Serialize(x, buffer)

        member x.ReadFrom(buffer : ZeroCopyBuffer) =
            let enumerator : IEnumerator<Froto.Serialization.Encoding.RawField> =
                ZeroCopyBuffer.allFields(buffer).GetEnumerator()
            while enumerator.MoveNext() do
                let current : Froto.Serialization.Encoding.RawField = enumerator.Current
                if current.FieldNum = 2 then
                    x.sub <- Some(Command.Discover(Primitives.readEmbedded<Discover> (current)))
                else if current.FieldNum = 1 then x.sub <- Some(Command.Poll(Primitives.readEmbedded<Poll> (current)))
                else ()
            enumerator.Dispose()

        member x.SerializedLength() = Primitives.serializedLength<Command> (x)

```


