### PR TITLE
Small fixes

### DIFF
--- a/Falanx.Ast/QuotationToAst.fs
+++ b/Falanx.Ast/QuotationToAst.fs
@@ -62,7 +62,6 @@ type Quotations() =
                 //dependencies.Append v.Type
                 let vType = sysTypeToSynType range v.Type knownNamespaces ommitEnclosingType
                 let spat = SynSimplePat.Id(mkIdent range v.Name, None, false ,false ,false, range)
-                //let untypedPat = SynSimplePats.SimplePats([spat], range)
                 let typedPat = SynSimplePats.SimplePats([SynSimplePat.Typed(spat, vType, range)], range)
                 let bodyAst = exprToAst body
                 SynExpr.Lambda(false, false, typedPat, bodyAst, range)

--- a/Falanx.Ast/QuotationToAst.fs
+++ b/Falanx.Ast/QuotationToAst.fs
@@ -62,8 +62,8 @@ type Quotations() =
                 //dependencies.Append v.Type
                 let vType = sysTypeToSynType range v.Type knownNamespaces ommitEnclosingType
                 let spat = SynSimplePat.Id(mkIdent range v.Name, None, false ,false ,false, range)
-                let untypedPat = SynSimplePats.SimplePats([spat], range)
-                let typedPat = SynSimplePats.Typed(untypedPat, vType, range)
+                //let untypedPat = SynSimplePats.SimplePats([spat], range)
+                let typedPat = SynSimplePats.SimplePats([SynSimplePat.Typed(spat, vType, range)], range)
                 let bodyAst = exprToAst body
                 SynExpr.Lambda(false, false, typedPat, bodyAst, range)
     

--- a/Falanx.BinaryCodec/Codec.fs
+++ b/Falanx.BinaryCodec/Codec.fs
@@ -107,15 +107,9 @@ namespace Falanx.BinaryCodec
                 |> Pack.toVarint (uint64 <| value.SerializedLength() )
                 |> value.Serialize
                 
-        /// Value is expected to be of type option<'T>. It's not possible
-        /// to use this type directly in the signature because of type providers limitations.
-        /// All optional non-generated types (i.e. primitive types and enums) should be serialized using
-        /// more strongly-typed writeOptional function
-        let writeOptionalEmbedded<'T when 'T :> IMessage> : Writer<obj> =
-            fun position buffer value ->
-                if not <| isNull value
-                then value :?> option<'T> |> Option.get |> writeEmbedded position buffer
-                
+        let writeOptionalEmbedded position buffer value =
+            value |> Option.iter (writeEmbedded position buffer)
+
         let writeUnionOptionalEmbedded unionType unionMembers =
             fun buffer value cases ->
                 match value with

--- a/Falanx.BinaryGenerator/CreateProto.fs
+++ b/Falanx.BinaryGenerator/CreateProto.fs
@@ -56,7 +56,10 @@ module Proto =
                            else Some(pr.DeclaringType :?> ProvidedRecord)
                        yield GenerationType.ProvidedRecord(pr, parent)
                    | pe when pe.IsEnum -> 
-                       let parent = Some(pe.DeclaringType :?> _)
+                       let parent = 
+                           match pe.DeclaringType with 
+                           | :? ProvidedRecord as pr -> Some pr
+                           | _ -> None
                        yield GenerationType.ProvidedEnum(pe :?> _, parent)
                    | _ -> () //TODO: this would be enums or other types
            ]

--- a/Falanx.BinaryGenerator/Serialization.fs
+++ b/Falanx.BinaryGenerator/Serialization.fs
@@ -85,7 +85,7 @@ module Serialization =
             | Class(_scope, _name), Optional -> 
                 Expr.callStaticGeneric 
                     [prop.Type.UnderlyingType] 
-                    [position; buffer; Expr.box value]  
+                    [position; buffer; value]  
                     <@@ writeOptionalEmbedded x x x @@>
             | Class(_scope, _name), Repeated ->
                 Expr.callStaticGeneric


### PR DESCRIPTION
* "Deep" generic types were getting generated as, for example, 
```fsharp 
type Msg = 
    { mutable bleh : ``ArraySegment<byte>`` option}
```
* Lambda's were being generated as `(fun x : int -> ...)` instead of `(fun (x : int) -> ...)`
* Top level enums would cause errors
* Exprs using `writeOptionalEmbedded` would cause fantomas to throw an exception "System.InvalidCastException: 'Unable to cast object of type 'Downcast' to type 'InferredUpcast'."
