### PR TITLE
fix module generation

### DIFF
--- a/Falanx.Ast/QuotationToAst.fs
+++ b/Falanx.Ast/QuotationToAst.fs
@@ -92,7 +92,11 @@ type Quotations() =
     
             | Application(left, right) ->
                 let synLeft = exprToAst left
-                let synRight = exprToAst right
+                let synRight = 
+                    let astRight = exprToAst right
+                    match right with 
+                    | (Value _ | Var _) -> astRight
+                    | _ -> SynExpr.Paren(astRight, range, None, range)
                 SynExpr.App(ExprAtomicFlag.NonAtomic, false, synLeft, synRight, range)
     
             | Sequential(left, right) ->

--- a/Falanx.BinaryGenerator/CreateProto.fs
+++ b/Falanx.BinaryGenerator/CreateProto.fs
@@ -10,8 +10,6 @@ module Proto =
     open Froto.Parser.ClassModel
     open FsAst
     open ProviderImplementation.ProvidedTypes
-    open Model
-    open System.Security.Claims
     
     let createProvidedTypes protoDef defaultnamespace =
         let protoFile = ProtoFile.fromString protoDef

--- a/Falanx.BinaryGenerator/CreateProto.fs
+++ b/Falanx.BinaryGenerator/CreateProto.fs
@@ -122,7 +122,7 @@ module Proto =
             ParsedInput.CreateImplFile(
                 ParsedImplFileInputRcd.CreateFs(outputFile)
                     .AddModule(
-                        SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong providedTypeRoot.Namespace)
+                        {SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong providedTypeRoot.Namespace) with IsRecursive = true}
                             .AddDeclarations ( [ yield openSystem
                                                  yield openFrotoSerialization
                                                  yield openSystemCollectionsGeneric

--- a/Falanx.BinaryGenerator/Model.fs
+++ b/Falanx.BinaryGenerator/Model.fs
@@ -52,10 +52,3 @@ module Model =
           Properties: PropertyDescriptor list
           OneOfGroups: OneOfDescriptor list
           Maps: MapDescriptor list }
-          
-    type GenerationType =
-        //ProvidedRecords will have a parent it they are defined inside another message, top level ones will not
-        | ProvidedRecord of ProvidedRecord * parent: ProvidedRecord option
-        //ProvidedUnions will always have a parent as they are specific to each message
-        | ProvidedUnion of ProvidedUnion * parent: ProvidedRecord option
-        | ProvidedEnum of ProvidedTypeDefinition * parent: ProvidedRecord option


### PR DESCRIPTION
Problems addressed:
1. nested records were not being placed in modules, though they would later be referenced as if they were
2. modules were assumed to only have one child so all subsequent nested items were top level
3. nested records also self referenced using the (now) enclosing module name
4. Code generated from `Expr.Application` (unlike `Expr.Call`) never bracketed any arguments causing issues with `UnionCaseTest` within arguments

To address (3), the generated namespace is now recursive. This has the side benefit of resolving #1 while keeping the original layout of the proto file.