### PR TITLE
reenable json tests

### DIFF
--- a/Falanx.Machinery/FSAstExtensions.fs
+++ b/Falanx.Machinery/FSAstExtensions.fs
@@ -72,17 +72,15 @@ namespace Falanx.Machinery
                     let synExpr, _parseTree =
                         Quotations.ToAst(ProvidedProperty.toExpr pp, ?ommitEnclosingType = ommitEnclosingType, ?knownNamespaces = knownNamespaces)
                     
-                    let flags =
-                        if pp.IsStatic then Some MemberFlags.StaticMember else Some MemberFlags.InstanceMember
-                        
-                    let parameters = []
+                    let flags = if pp.IsStatic then Some MemberFlags.StaticMember else Some MemberFlags.InstanceMember
                        
                     SynMemberDefn.CreateMember
                         { SynBindingRcd.Null with
-                            Pattern = SynPatRcd.CreateLongIdent(ident, [ SynPatRcd.CreateParen(SynPatRcd.CreateTuple parameters) ] )
+                            Pattern = SynPatRcd.CreateLongIdent(ident, [ ] )
                             Expr = synExpr
                             ValData = SynValData(flags, SynValInfo.Empty, None)
                         }
+                        
         type SynFieldRcd with               
             static member CreateFromPropertyInfo(pp: Reflection.PropertyInfo, isMutable, ?ommitEnclosingType) =
                 let typeName = SynType.CreateFromType(pp.PropertyType, ?ommitEnclosingType = ommitEnclosingType)

--- a/Falanx.Machinery/ProvidedAdapter.fs
+++ b/Falanx.Machinery/ProvidedAdapter.fs
@@ -21,6 +21,7 @@ module ProvidedMethod =
         
 [<RequireQualifiedAccess>]
 module ProvidedProperty =
+    ///Note: this only support Properties with a getter
     let toExpr (m:ProvidedProperty) =
         let getter = match m.Getter with Some getter -> getter() | _ -> failwith "No getter"
         match getter with

--- a/Falanx.Machinery/ProvidedTypesExtensions.fs
+++ b/Falanx.Machinery/ProvidedTypesExtensions.fs
@@ -131,5 +131,5 @@ module ProvidedUnion =
 module ProvidedRecord =
     let getRecordFields (providedRecord: ProvidedRecord) =
         providedRecord.GetProperties()
-        |> Array.choose (function :? ProvidedProperty as pp -> Some pp | _ -> None)
+        |> Array.choose (function :? ProvidedProperty as pp -> Some (pp :> PropertyInfo) | _ -> None)
         |> Array.toList

--- a/Falanx.Proto.Codec.Json/Codec.fs
+++ b/Falanx.Proto.Codec.Json/Codec.fs
@@ -35,7 +35,7 @@ module Quotations =
           for ex in args do yield! traverseForCall ex
       | Quotations.ExprShape.ShapeVar _ -> () ]
 
-module temp =    
+module Codec =    
     let cleanUpTypeName (str:string) =
         let sb = Text.StringBuilder(str)
         sb.Replace("System.", "")
@@ -88,7 +88,7 @@ module temp =
     
     let createLambdaRecord (recordType: ProvidedRecord) =
         //Lambda (u, Lambda (t, NewRecord (Result2, u, t))
-        let recordFields = ProvidedRecord.getRecordFields recordType
+        let recordFields = recordType.RecordFields
         let recordVars =
             recordFields
             |> List.map(fun pi -> Var(pi.Name, pi.PropertyType))
@@ -397,26 +397,19 @@ module temp =
                                        None
                                     | _ -> None) expr
 
-    let tryCode (typeDescriptor: TypeDescriptor) =
+    let createJsonObjCodec (typeDescriptor: TypeDescriptor) =
 
         let recordType = typeDescriptor.Type :?> ProvidedRecord
         let lambdaRecord = createLambdaRecord recordType
         let mapping = callMapping lambdaRecord
         let pipeLambdaToMapping = callPipeRight lambdaRecord mapping
         
-        let recordFields = ProvidedRecord.getRecordFields recordType
+        let recordFields = recordType.RecordFields
             
         let jFieldOpts = createRecordJFieldOpts recordFields recordType
         let allPipedFunctions = [yield lambdaRecord; yield mapping; yield! jFieldOpts]
         let foldedFunctions = allPipedFunctions |> List.reduce callPipeRight
                          
-
-//        let firstJfieldOpt = callJfieldopt recordType (Expr.propertyof<@ (x:Result2).url @>) typeof<string> (Some typeof<int>)
-//        let secondJFieldOpt = callJfieldopt recordType (Expr.propertyof<@ (x:Result2).title @>) typeof<int> None
-//        
-//        let pipeLambdaToMappingToFirstJFieldOpt = callPipeRight pipeLambdaToMapping firstJfieldOpt
-//        let pipeLambdaToMappingToFirstJFieldOptToSecondJFieldOpt = callPipeRight pipeLambdaToMappingToFirstJFieldOpt secondJFieldOpt
-//        
 //        let qs = ProviderImplementation.ProvidedTypes.QuotationSimplifier(true)
 //        let simplified = qs.Simplify pipeLambdaToMappingToFirstJFieldOptToSecondJFieldOpt
         

--- a/Falanx.Proto.Codec.Json/Codec.fs
+++ b/Falanx.Proto.Codec.Json/Codec.fs
@@ -441,5 +441,5 @@ module temp =
             let def = typedefof<Codec<IReadOnlyDictionary<string,JsonValue>,_>>
             def.MakeGenericType [|typeof<IReadOnlyDictionary<string,JsonValue>>; typeDescriptor.Type :> _ |]
             
-        let createJsonObjCodec = ProvidedMethod("JsonObjCodec", [], signatureType, invokeCode = (fun args -> foldedFunctions), isStatic = true )
+        let createJsonObjCodec = ProvidedProperty("JsonObjCodec",signatureType, getterCode = (fun args -> foldedFunctions), isStatic = true )
         createJsonObjCodec

--- a/Falanx.Proto.Codec.Json/Codec.fs
+++ b/Falanx.Proto.Codec.Json/Codec.fs
@@ -193,7 +193,7 @@ module Codec =
 //        expr
 
         
-    let callJfieldopt (recordType: Type) propertyInfo (fieldType: Type ) (nextFieldType: Type) =
+    let callJfieldopt (recordType: Type) (propertyInfo: PropertyInfo) (fieldType: Type ) (nextFieldType: Type) =
         // fun u t -> { url = u; title= t }
         // |> mapping<Option<String> -> Option<int> -> Result2, IReadOnlyDictionary<String, JToken>, String, Result2, String, JToken>
         // |> jfieldopt<Result2, string, Option<int> -> Result2> "url"   (fun x -> x.url)
@@ -207,7 +207,7 @@ module Codec =
             ProvidedTypeBuilder.MakeGenericMethod(jfieldoptMethodInfo, jFieldTypeArguments)
         let formattedjfieldoptMethodInfoTyped = sprintf "%s" (jfieldoptMethodInfoTyped.ToString() |> cleanUpTypeName)
         
-        let fieldName = Expr.Value fieldType.Name //should ideally be protodecriptor.name
+        let fieldName = Expr.Value propertyInfo.Name //should ideally be protodecriptor.name
         
         let xvar = Var("x", recordType)
         

--- a/Falanx.Proto.Generator/CreateProto.fs
+++ b/Falanx.Proto.Generator/CreateProto.fs
@@ -54,7 +54,7 @@ module Proto =
             [ yield providedTypeRoot.Namespace
               yield "System"
               yield "System.Collections.Generic"
-              if codecs |> Set.contains Binary then
+              if codecs.Contains Binary then
                   yield "Froto.Serialization"
                   yield "Falanx.Proto.Codec.Binary"
                   yield "Falanx.Proto.Codec.Binary.Primitives"
@@ -93,7 +93,7 @@ module Proto =
                         {SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong providedTypeRoot.Namespace) with IsRecursive = true}
                             .AddDeclarations ( [ yield openSystem
                                                  yield openSystemCollectionsGeneric
-                                                 if codecs |> Set.contains Binary then
+                                                 if codecs.Contains Binary then
                                                      yield openFrotoSerialization
                                                      yield openBinaryCodec
                                                      yield openBinaryCodecPrimitive

--- a/Falanx.Proto.Generator/CreateProto.fs
+++ b/Falanx.Proto.Generator/CreateProto.fs
@@ -51,17 +51,19 @@ module Proto =
         let openBinaryCodecPrimitive = SynModuleDecl.CreateOpen (LongIdentWithDots.CreateString "Falanx.Proto.Codec.Binary.Primitives")
         
         let knownNamespaces =
-            [ providedTypeRoot.Namespace
-              "System"
-              "Froto.Serialization"
-              "System.Collections.Generic"
-              "Falanx.Proto.Codec.Binary"
-              "Falanx.Proto.Codec.Binary.Primitives"
-              "Microsoft.FSharp.Core"
-              "Microsoft.FSharp.Core.Operators"
-              "Microsoft.FSharp.Collections"
-              "Microsoft.FSharp.Control"
-              "Microsoft.FSharp.Text" ]
+            [ yield providedTypeRoot.Namespace
+              yield "System"
+              yield "System.Collections.Generic"
+              if codecs |> Set.contains Binary then
+                  yield "Froto.Serialization"
+                  yield "Falanx.Proto.Codec.Binary"
+                  yield "Falanx.Proto.Codec.Binary.Primitives"
+              
+              yield "Microsoft.FSharp.Core"
+              yield "Microsoft.FSharp.Core.Operators"
+              yield "Microsoft.FSharp.Collections"
+              yield "Microsoft.FSharp.Control"
+              yield "Microsoft.FSharp.Text" ]
             |> Set.ofSeq
             
         let synTypes =   
@@ -90,10 +92,11 @@ module Proto =
                     .AddModule(
                         {SynModuleOrNamespaceRcd.CreateNamespace(Ident.CreateLong providedTypeRoot.Namespace) with IsRecursive = true}
                             .AddDeclarations ( [ yield openSystem
-                                                 yield openFrotoSerialization
                                                  yield openSystemCollectionsGeneric
-                                                 yield openBinaryCodec
-                                                 yield openBinaryCodecPrimitive
+                                                 if codecs |> Set.contains Binary then
+                                                     yield openFrotoSerialization
+                                                     yield openBinaryCodec
+                                                     yield openBinaryCodecPrimitive
                                                  yield! synTypes] )
                     )
             )

--- a/Falanx.Proto.Generator/TypeGeneration.fs
+++ b/Falanx.Proto.Generator/TypeGeneration.fs
@@ -230,7 +230,6 @@ module TypeGeneration =
                                      Some(createOneOfDescriptor nestedScope lookup name members)
                                  | _ -> None)
 
-                     
              for oneOfDescriptor in oneOfDescriptors do
                  providedType.AddMembers [ oneOfDescriptor.OneOfType :> MemberInfo
                                            oneOfDescriptor.CaseField :> _
@@ -242,15 +241,14 @@ module TypeGeneration =
         
              for prop in properties do
                  providedType.AddMember prop.ProvidedProperty
-                 providedType.AddMember prop.ProvidedField.Value
+                 prop.ProvidedField |> Option.iter providedType.AddMember
         
              let maps = 
                  message.Parts
-                 |> Seq.choose (function
+                 |> List.choose (function
                                 | TMap(name, keyTy, valueTy, position, _) ->
                                     Some(createMapDescriptor nestedScope lookup name keyTy valueTy position)
                                 | _ -> None)
-                 |> List.ofSeq
         
              for map in maps do
                  providedType.AddMember map.ProvidedField

--- a/Falanx.Proto.Generator/TypeGeneration.fs
+++ b/Falanx.Proto.Generator/TypeGeneration.fs
@@ -34,8 +34,10 @@ module TypeGeneration =
     
         let property, backingField = 
             match field.Rule with
-            | Repeated -> ProvidedTypeDefinition.mkPropertyWithField propertyType propertyName true
-            | _ -> ProvidedTypeDefinition.mkPropertyWithField propertyType propertyName false
+            | Repeated ->
+                ProvidedTypeDefinition.mkRecordPropertyWithField propertyType propertyName true
+            | _ ->
+                ProvidedTypeDefinition.mkRecordPropertyWithField propertyType propertyName false
             
         //apply custom attributes for record field
         let constructor = typeof<CompilationMappingAttribute>.TryGetConstructor([|typeof<SourceConstructFlags>; typeof<int> |])
@@ -278,7 +280,7 @@ module TypeGeneration =
                                  providedType.AddMember serializedLengthMethod
                                  providedType.DefineMethodOverride(serializedLengthMethod, typeof<IMessage>.GetMethod("SerializedLength"))
                           | Json ->
-                              let jsonObjCodec = Falanx.Proto.Codec.Json.temp.tryCode typeInfo
+                              let jsonObjCodec = Falanx.Proto.Codec.Json.Codec.createJsonObjCodec typeInfo
                               providedType.AddMember jsonObjCodec
                          )
                           

--- a/test/Falanx.IntegrationTests/Sample.fs
+++ b/test/Falanx.IntegrationTests/Sample.fs
@@ -242,6 +242,13 @@ let tests pkgUnderTestVersion =
         |> buildExampleWithTemplate fs ``template1 binary`` ``sample5 pkg``
       )
 
+      testCase |> withLog "can build sample7 json" (fun _ fs ->
+        let testDir = inDir fs "sanity_check_sample7_json"
+
+        testDir
+        |> buildExampleWithTemplate fs ``template2 json`` ``sample7 itemLevelOrderHistory``
+      )
+
     ]
 
   let sdkIntegrationMocks =

--- a/test/Falanx.IntegrationTests/Sample.fs
+++ b/test/Falanx.IntegrationTests/Sample.fs
@@ -19,8 +19,15 @@ let TestRunDirToolDir = TestRunDir/"tool"
 let NupkgsDir = RepoDir/"artifact"/"nupkg"
 let NugetOrgV3Url = "https://api.nuget.org/v3/index.json"
 
+let stdOutLines (cmd: Command) =
+    cmd.Result.StandardOutput
+    |> fun s -> s.Trim()
+    |> fun s -> s.Split(Environment.NewLine)
+    |> List.ofArray
+
 let checkExitCodeZero (cmd: Command) =
-    Expect.equal 0 cmd.Result.ExitCode "command finished with exit code non-zero."
+    "command finished with exit code non-zero"
+    |> Expect.equal cmd.Result.ExitCode 0
 
 let dotnetCmd (fs: FileUtils) args =
     fs.shellExecRun "dotnet" args
@@ -156,14 +163,6 @@ let tests pkgUnderTestVersion =
     fs.cd outDir
     outDir
 
-  let asLines (s: string) =
-    s.Split(Environment.NewLine) |> List.ofArray
-
-  let stdOutLines (cmd: Command) =
-    cmd.Result.StandardOutput
-    |> fun s -> s.Trim()
-    |> asLines
-
   let generalTests =
     testList "general" [
       testCase |> withLog "can show help" (fun _ fs ->
@@ -224,12 +223,16 @@ let tests pkgUnderTestVersion =
       testCase |> withLog "can build sample3 json" (fun _ fs ->
         let testDir = inDir fs "sanity_check_sample3_json"
 
+        Tests.skiptest "schema with collection and json format doesnt work yet"
+
         testDir
         |> buildExampleWithTemplate fs ``template2 json`` ``sample6 bundle``
       )
 
       testCase |> withLog "can build sample4 binary+json" (fun _ fs ->
         let testDir = inDir fs "sanity_check_sample4_binaryjson"
+
+        Tests.skiptest "schema with collection and json format doesnt work yet"
 
         testDir
         |> buildExampleWithTemplate fs ``template3 binary+json`` ``sample6 bundle``

--- a/test/Falanx.IntegrationTests/Sample.fs
+++ b/test/Falanx.IntegrationTests/Sample.fs
@@ -224,16 +224,12 @@ let tests pkgUnderTestVersion =
       testCase |> withLog "can build sample3 json" (fun _ fs ->
         let testDir = inDir fs "sanity_check_sample3_json"
 
-        Tests.skiptest "only json doesnt work yet"
-
         testDir
         |> buildExampleWithTemplate fs ``template2 json`` ``sample6 bundle``
       )
 
       testCase |> withLog "can build sample4 binary+json" (fun _ fs ->
         let testDir = inDir fs "sanity_check_sample4_binaryjson"
-
-        Tests.skiptest "doesnt contains a json serialization/deserialization"
 
         testDir
         |> buildExampleWithTemplate fs ``template3 binary+json`` ``sample6 bundle``

--- a/test/Falanx.IntegrationTests/TestAssets.fs
+++ b/test/Falanx.IntegrationTests/TestAssets.fs
@@ -50,6 +50,14 @@ let ``template4 scala`` =
     AssemblyName = "src"/"main"/"scala"
     ProtoFile = "src"/"main"/"protobuf"/"ItemLevelOrderHistory.proto" }
 
+let ``template5 scala json`` =
+  { ProjDir = "template5 scala json"
+    Language = Scala
+    RequiredFormats = [Json]
+    ProjectFile = "src"/"main"/"scala"/"Program.scala"
+    AssemblyName = "src"/"main"/"scala"
+    ProtoFile = "src"/"main"/"protobuf"/"ItemLevelOrderHistory.proto" }
+
 type FalanxMock =
   { ProjDir: string
     FileName: string }
@@ -75,5 +83,9 @@ let ``sample6 bundle`` =
 
 let ``sample7 itemLevelOrderHistory`` =
   { ExampleDir = "sample7 itemLevelOrderHistory"
-    FileNames = [FSharp, Binary, "BinaryExample.fs"; FSharp, Json, "JsonExample.fs"; Scala, Binary, "BinaryExample.scala"]
+    FileNames =
+      [ FSharp, Binary, "BinaryExample.fs"
+        FSharp, Json, "JsonExample.fs"
+        Scala, Binary, "BinaryExample.scala"
+        Scala, Json, "JsonExample.scala" ]
     ProtoFile = "ItemLevelOrderHistory.proto" }

--- a/test/Falanx.IntegrationTests/TestAssets.fs
+++ b/test/Falanx.IntegrationTests/TestAssets.fs
@@ -75,5 +75,5 @@ let ``sample6 bundle`` =
 
 let ``sample7 itemLevelOrderHistory`` =
   { ExampleDir = "sample7 itemLevelOrderHistory"
-    FileNames = [FSharp, Binary, "BinaryExample.fs"; Scala, Binary, "BinaryExample.scala"]
+    FileNames = [FSharp, Binary, "BinaryExample.fs"; FSharp, Json, "JsonExample.fs"; Scala, Binary, "BinaryExample.scala"]
     ProtoFile = "ItemLevelOrderHistory.proto" }

--- a/test/examples/sample7 itemLevelOrderHistory/JsonExample.fs
+++ b/test/examples/sample7 itemLevelOrderHistory/JsonExample.fs
@@ -1,0 +1,24 @@
+module JsonExample
+
+open l1.Contracts
+open Fleece.Newtonsoft
+
+let serialize () : string =
+    let r =
+        { ItemLevelOrderHistory.clientId = Some "clientA"
+          retailSkuId = Some "sku12345"
+          categoryId = Some 78.91
+          brand = Some "myBrand1"
+          product = Some "p100"
+          orderTss = Some 43.21f }
+
+    toJson r |> string
+
+let deserialize (jsonText: string) : ItemLevelOrderHistory =
+
+    let s = parseJson<ItemLevelOrderHistory> jsonText
+
+    match s with
+    | Result.Ok x -> x
+    | Result.Error err -> failwithf "error parsing json: '%A'" err
+    

--- a/test/examples/sample7 itemLevelOrderHistory/JsonExample.scala
+++ b/test/examples/sample7 itemLevelOrderHistory/JsonExample.scala
@@ -1,0 +1,21 @@
+class JsonExample {
+
+  def serialize() = {
+    val item =
+      ItemLevelOrderHistory()
+        .withClientId("client1")
+        .withRetailSkuId("sku1")
+        .withCategoryId(12.3)
+        .withBrand("brandA")
+        .withProduct("product1")
+        .withOrderTss(45.6f)
+
+    val jsonText: String = scalapb.json4s.JsonFormat.toJsonString(item)
+    jsonText
+  }
+
+  def deserialize(jsonText: String) = {
+    val item2: ItemLevelOrderHistory = scalapb.json4s.JsonFormat.fromJsonString[ItemLevelOrderHistory](jsonText)
+    item2
+  }
+}

--- a/test/examples/template2 json/l1/Program.fs
+++ b/test/examples/template2 json/l1/Program.fs
@@ -24,12 +24,12 @@ module Program =
             printfn "Serialized:"
             printfn "%A" bytes
 
-            File.WriteAllBytes(path, bytes)
+            File.WriteAllText(path, bytes)
 
         | Deserialize (path, outputPath) ->
-            let bytes = File.ReadAllBytes(path)
+            let jsonText = File.ReadAllText(path)
 
-            let s = JsonExample.deserialize bytes
+            let s = JsonExample.deserialize jsonText
 
             printfn "Deserialized:"
             printfn "%A" s

--- a/test/examples/template3 binaryjson/l1/Program.fs
+++ b/test/examples/template3 binaryjson/l1/Program.fs
@@ -15,12 +15,12 @@ module Program =
         printfn "[BINARY] Deserialized:"
         printfn "%A" s
 
-        let bytes = JsonExample.serialize ()
+        let jsonText = JsonExample.serialize ()
 
         printfn "[JSON] Serialized:"
-        printfn "%A" bytes
+        printfn "%A" jsonText
 
-        let s = JsonExample.deserialize bytes
+        let s = JsonExample.deserialize jsonText
 
         printfn "[JSON] Deserialized:"
         printfn "%A" s

--- a/test/examples/template5 scala json/build.sbt
+++ b/test/examples/template5 scala json/build.sbt
@@ -1,0 +1,11 @@
+name := "sample7 scala"
+
+version := "0.1"
+
+scalaVersion := "2.12.7"
+
+PB.targets in Compile := Seq(
+  scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value
+)
+
+libraryDependencies += "com.thesamet.scalapb" %% "scalapb-json4s" % "0.7.1"

--- a/test/examples/template5 scala json/project/build.properties
+++ b/test/examples/template5 scala json/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.6

--- a/test/examples/template5 scala json/project/scalapb.sbt
+++ b/test/examples/template5 scala json/project/scalapb.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.2"

--- a/test/examples/template5 scala json/src/main/scala/Program.scala
+++ b/test/examples/template5 scala json/src/main/scala/Program.scala
@@ -1,5 +1,6 @@
 import java.nio.file.{Files, Paths}
 import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
 
 object Program {
 
@@ -27,8 +28,8 @@ object Program {
         Files.write(Paths.get(path), bytes)
       }
       case Deserialize(path, out) => {
-        val lines = Files.readAllLines(Paths.get(path))
-        val jsonText = lines.get(0)
+        val lines = Files.readAllLines(Paths.get(path)).asScala.toList
+        val jsonText = lines.mkString(System.lineSeparator())
         val item2 = example.deserialize(jsonText)
         println(item2)
         Files.write(Paths.get(out), item2.toString().getBytes(StandardCharsets.UTF_8))

--- a/test/examples/template5 scala json/src/main/scala/Program.scala
+++ b/test/examples/template5 scala json/src/main/scala/Program.scala
@@ -1,0 +1,39 @@
+import java.nio.file.{Files, Paths}
+import java.nio.charset.StandardCharsets
+
+object Program {
+
+  sealed trait Command
+  case class Serialize(path: String) extends Command
+  case class Deserialize(path: String, out: String) extends Command
+
+
+  def main(args: Array[String]): Unit = {
+
+    val cmd =
+      args match {
+        case Array("--serialize", p) => Serialize(p)
+        case Array("--deserialize", p, "--out", o) => Deserialize(p, o)
+        case _ => throw new Exception("invalid args, expecting --serialize or --deserialize")
+      }
+
+    val example = new JsonExample
+
+    cmd match {
+      case Serialize(path) => {
+        val jsonText = example.serialize()
+        println(jsonText)
+        val bytes = jsonText.getBytes(StandardCharsets.UTF_8)
+        Files.write(Paths.get(path), bytes)
+      }
+      case Deserialize(path, out) => {
+        val lines = Files.readAllLines(Paths.get(path))
+        val jsonText = lines.get(0)
+        val item2 = example.deserialize(jsonText)
+        println(item2)
+        Files.write(Paths.get(out), item2.toString().getBytes(StandardCharsets.UTF_8))
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Support json as format using a flat schema

reenable json tests:

- `proto schema with collection` test is skipped, expected to not work
- `proto schema with just fields (flat)` test is reenabled
- added scala json interop
    - sanity check scala -> json -> scala
    - scala -> json -> .net
    - .net -> json -> scala
