### PR TITLE
Fix binary serialization of repeated enum

### DIFF
--- a/Falanx.Proto.Codec.Binary/Serialization.fs
+++ b/Falanx.Proto.Codec.Binary/Serialization.fs
@@ -97,18 +97,21 @@ module Serialization =
                 let intMethod = 
                     let arg = Var("x",prop.Type.UnderlyingType)
                     Expr.Lambda(arg, Expr.callStaticGeneric [prop.Type.UnderlyingType] [Expr.Var arg] <@int x@>)
-                let optMap = Expr.callStaticGeneric [prop.Type.UnderlyingType; typeof<int>] [intMethod; value] <@Option.map x x@>
                 match rule with 
                 | Optional -> 
+                    let optMap = Expr.callStaticGeneric [prop.Type.UnderlyingType; typeof<int>] [intMethod; value] <@Option.map x x@>
                     Expr.callStaticGeneric 
                         [typeof<int>]
                         [ <@@ writeInt32 @@> ;position; buffer; optMap]
                         <@@ writeOption x x x x @@>
-                | Required -> Expr.apply <@@ writeInt32 @@> [position; buffer; optMap]
+                | Required ->
+                    let optMap = Expr.callStaticGeneric [prop.Type.UnderlyingType; typeof<int>] [intMethod; value] <@Option.map x x@>
+                    Expr.apply <@@ writeInt32 @@> [position; buffer; optMap]
                 | Repeated -> 
+                    let seqMap = Expr.callStaticGeneric [prop.Type.UnderlyingType; typeof<int>] [intMethod; value] <@Seq.map x x@>
                     Expr.callStaticGeneric 
                         [typeof<int>]
-                        [ <@@ writeInt32 @@> ;position; buffer; optMap]
+                        [ <@@ writeInt32 @@> ;position; buffer; seqMap]
                         <@@ writeRepeated x x x x @@>
             | Primitive, rule ->
                 callPrimitive (primitiveWriter prop.Type.ProtobufType) prop rule position buffer value


### PR DESCRIPTION
Repeated enums need to use Seq.map instead of Option.map to convert each entry
from the enum to an integer.

For example, a proto of

```
enum Foo {
  Foo = 0;
  Bar = 1;
}

message FooMsg {
  repeated Foo foos = 1;
}
```

will currently try and call Option.map when encoding foos, but should instead call Seq.map