### PR TITLE
rework sdk integration

### DIFF
--- a/Falanx.Sdk/build/Falanx.Sdk.targets
+++ b/Falanx.Sdk/build/Falanx.Sdk.targets
@@ -1,63 +1,35 @@
-<Project TreatAsLocalProperty="
-         FalanxSdk_CodeGenDirectory;
-         FalanxSdk_CodeGeneratorEnabled;
-         FalanxSdk_DotNetHost;
-         FalanxSdk_MSBuildIsCore;
-         FalanxSdk_OutputFileName;
-         FalanxSdk_InputFileName;
-         FalanxSdk_TargetIsCore;
-         FalanxSdk_TaskAssembly;
-         FalanxSdk_CodeGeneratorTargetFramework;">
+<Project>
 
-  <PropertyGroup>
-    <FalanxSdk_CodeGeneratorTargetFramework>netcoreapp2.0</FalanxSdk_CodeGeneratorTargetFramework>
-    <FalanxSdk_DotNetHost>dotnet</FalanxSdk_DotNetHost>
-
-    <!-- Specify the assembly containing the MSBuild tasks. -->
-    <FalanxSdk_MSBuildIsCore Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(OS)' != 'Windows_NT'">true</FalanxSdk_MSBuildIsCore>
-    <FalanxSdk_TaskAssembly Condition="'$(FalanxSdkCodeGenTasksAssembly)' != ''">$(FalanxSdkCodeGenTasksAssembly)</FalanxSdk_TaskAssembly>
-    <FalanxSdk_TaskAssembly Condition="'$(FalanxSdk_TaskAssembly)' == '' and '$(FalanxSdk_MSBuildIsCore)' == 'true'">$(MSBuildThisFileDirectory)..\tasks\$(FalanxSdk_CodeGeneratorTargetFramework)\FalanxSdk.CodeGenerator.MSBuild.Tasks.dll</FalanxSdk_TaskAssembly>
-
-    <!-- When the MSBuild host is full-framework, we defer to PATH for dotnet -->
-    <FalanxSdk_DotNetHost Condition="'$(FalanxSdk_MSBuildIsCore)' != 'true'">dotnet</FalanxSdk_DotNetHost>
-    <FalanxSdk_DotNetHost Condition="'$(DotNetHost)' != ''">$(DotNetHost)</FalanxSdk_DotNetHost>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <FalanxSdkCodeGenLogLevel Condition="'$(FalanxSdkCodeGenLogLevel)' == ''">Warning</FalanxSdkCodeGenLogLevel>
-    <FalanxSdk_CodeGenDirectory Condition="'$([System.IO.Path]::IsPathRooted($(IntermediateOutputPath)))' == 'true'">$(IntermediateOutputPath)</FalanxSdk_CodeGenDirectory>
-    <FalanxSdk_CodeGenDirectory Condition="'$(FalanxSdk_CodeGenDirectory)' == ''">$(ProjectDir)$(IntermediateOutputPath)</FalanxSdk_CodeGenDirectory>
-    <FalanxSdk_OutputFileName>$(FalanxSdk_CodeGenDirectory)$(TargetName).FalanxSdk.g.fs</FalanxSdk_OutputFileName>
-    <FalanxSdk_CodeGeneratorEnabled Condition=" '$(DesignTimeBuild)' != 'true'">true</FalanxSdk_CodeGeneratorEnabled>
-    <FalanxSdkGenerateCodeDependsOn>$(FalanxSdkGenerateCodeDependsOn);ResolveReferences;FalanxSdkGenerateInputCache</FalanxSdkGenerateCodeDependsOn>
-    <FalanxSdk_InputFileName>@(ProtoFile -> '%(FullPath)')</FalanxSdk_InputFileName>
-  </PropertyGroup>
-  
   <!--
     Input to the code generator should not include its output.
   -->
-  <ItemGroup>
-    <FalanxSdk_CodeGenInputs Include="$(FalanxSdk_InputFileName);@(ReferencePath)" />
-    <FalanxSdk_CodeGenInputs Remove="$(FalanxSdk_OutputFileName)" />
-  </ItemGroup>
-
-  <!-- Properties used to support correct, incremental builds. -->
-  <PropertyGroup>
+  <Target Name="_FalanxSdkProtoFilesList"
+          BeforeTargets="FalanxSdkGenerateInputCache">
+    <ItemGroup>
+      <ProtoFileCodegen Include="%(ProtoFile.FullPath)">
+        <OutputPath Condition=" '%(ProtoFile.OutputPath)' != '' ">$([System.IO.Path]::GetFullPath('%(ProtoFile.OutputPath)')</OutputPath>
+        <OutputPath Condition=" '%(ProtoFile.OutputPath)' == '' ">%(ProtoFile.FullPath).fs</OutputPath>
+      </ProtoFileCodegen>
+    </ItemGroup>
     <!--
-      Since the FalanxSdk code generator also affects the state of @(Compile) and hence the compile inputs file,
-      we maintain a separate cache with FalanxSdk' own files removed. Otherwise there would be a circular dependency
-      whereby the cache updates and triggers the code generator, which triggers a cache update.
+
     -->
-    <FalanxSdk_CodeGenInputCache>$(IntermediateOutputPath)$(MSBuildProjectFile).FalanxSdkCodeGenInputs.cache</FalanxSdk_CodeGenInputCache>
-  </PropertyGroup>
+    <PropertyGroup>
+      <_FalanxSdkCodeGenInputCache>$(IntermediateOutputPath)$(MSBuildProjectFile).FalanxSdkCodeGenInputs.cache</_FalanxSdkCodeGenInputCache>
+    </PropertyGroup>
+  </Target>
 
   <!--
     Update the file which captures the total set of all inputs to the code generator.
     This is based on the _GenerateCompileDependencyCache target from the .NET project system.
   -->
   <Target Name="FalanxSdkGenerateInputCache"
-          DependsOnTargets="ResolveAssemblyReferences"
+          DependsOnTargets="ResolveAssemblyReferences;_FalanxSdkProtoFilesList"
           BeforeTargets="FalanxSdkGenerateCode">
+
+    <ItemGroup>
+      <FalanxSdk_CodeGenInputs Include="@(ProtoFileCodegen);@(ReferencePath)" />
+    </ItemGroup>
 
     <Hash ItemsToHash="@(FalanxSdk_CodeGenInputs)">
       <Output TaskParameter="HashResult" PropertyName="FalanxSdk_UpdatedInputCacheContents" />
@@ -65,50 +37,49 @@
 
     <WriteLinesToFile
       Overwrite="true"
-      File="$(FalanxSdk_CodeGenInputCache)"
+      File="$(_FalanxSdkCodeGenInputCache)"
       Lines="$(FalanxSdk_UpdatedInputCacheContents)"
       WriteOnlyWhenDifferent="True" />
 
-    <ItemGroup>
-      <FileWrites Include="$(FalanxSdk_CodeGenInputCache)" />
-    </ItemGroup>
-    
   </Target>
+
+  <PropertyGroup>
+    <FalanxSdkGenerateCodeDependsOn>$(FalanxSdkGenerateCodeDependsOn);ResolveReferences;FalanxSdkGenerateInputCache</FalanxSdkGenerateCodeDependsOn>
+  </PropertyGroup>
 
   <Target Name="FalanxSdkGenerateCode"
           DependsOnTargets="$(FalanxSdkGenerateCodeDependsOn)"
-          AfterTargets="FalanxSdkGenerateInputCache"
           BeforeTargets="CoreCompile"
-          Condition="'$(FalanxSdk_CodeGeneratorEnabled)' == 'true'"
-          Inputs="@(FalanxSdk_CodeGenInputs);$(FalanxSdk_CodeGenInputCache)"
-          Outputs="$(FalanxSdk_OutputFileName)">
+          Condition=" '$(DesignTimeBuild)' != 'true' "
+          Inputs="@(ProtoFileCodegen);$(_FalanxSdkCodeGenInputCache)"
+          Outputs="%(ProtoFileCodegen.OutputPath)">
 
     <PropertyGroup>
-      <_FalanxSdk_InputFileName>$(FalanxSdk_InputFileName)</_FalanxSdk_InputFileName>
+      <_FalanxSdk_InputFileName>%(ProtoFileCodegen.Identity)</_FalanxSdk_InputFileName>
+      <_FalanxSdk_OutputFileName>%(ProtoFileCodegen.OutputPath)</_FalanxSdk_OutputFileName>
     </PropertyGroup>
 
     <ItemGroup>
       <FalanxSdk_CodeGenArgs Include='--inputfile "$(_FalanxSdk_InputFileName)"' />
-      <FalanxSdk_CodeGenArgs Include='--outputfile "$(FalanxSdk_OutputFileName)"' />
+      <FalanxSdk_CodeGenArgs Include='--outputfile "$(_FalanxSdk_OutputFileName)"' />
       <FalanxSdk_CodeGenArgs Include='--defaultnamespace "$(RootNamespace)"' />
       <FalanxSdk_CodeGenArgs Include='--serializer %(FalanxSdkSerializer.Identity)' />
     </ItemGroup>
 
     <!-- Use dotnet to execute the process. -->
-    <Exec Command="$(FalanxSdk_GeneratorExeHost)&quot;$(FalanxSdk_GeneratorExe)&quot; @(FalanxSdk_CodeGenArgs -> '%(Identity)', ' ')" Outputs="$(FalanxSdk_OutputFileName)" />
+    <Exec Command="$(FalanxSdk_GeneratorExeHost)&quot;$(FalanxSdk_GeneratorExe)&quot; @(FalanxSdk_CodeGenArgs -> '%(Identity)', ' ')" />
 
     <ItemGroup>
-      <Compile Include="$(FalanxSdk_OutputFileName)" Condition="Exists('$(FalanxSdk_OutputFileName)')" />
-      <FileWrites Include="$(FalanxSdk_OutputFileName)" Condition="Exists('$(FalanxSdk_OutputFileName)')"/>
+      <CompileBefore Include="$(_FalanxSdk_OutputFileName)" Condition="Exists('$(_FalanxSdk_OutputFileName)')" />
     </ItemGroup>
   </Target>
 
   <Target Name="FalanxSdkIncludeCodegenOutputDuringDesignTimeBuild"
           BeforeTargets="CoreCompile"
-          Condition="'$(FalanxSdk_CodeGeneratorEnabled)' != 'true' and Exists('$(FalanxSdk_OutputFileName)')">
+          Condition=" '$(DesignTimeBuild)' == 'true' ">
     <ItemGroup>
-      <Compile Include="$(FalanxSdk_OutputFileName)"/>
-      <FileWrites Include="$(FalanxSdk_OutputFileName)"/>
+      <Compile Include="%(ProtoFileCodegen.OutputPath)" />
     </ItemGroup>
   </Target>
+
 </Project>

--- a/test/Falanx.IntegrationTests/Sample.fs
+++ b/test/Falanx.IntegrationTests/Sample.fs
@@ -249,62 +249,81 @@ let tests pkgUnderTestVersion =
 
   let sdkIntegrationMocks =
 
-    let dotnetBuildWithFalanxArgsMock (fs: FileUtils) testDir projPath =
+    let replaceRealFalanxEnvVar realPath mockFilename =
+        let mockPath = sprintf "%s.bat" mockFilename
+        let content = File.ReadAllText(mockPath)
+        let newContent = content.Replace("%REAL_FALANX%", realPath)
+        File.WriteAllText(mockPath, newContent)
+
+    let dotnetBuildWithFalanxArgsMockAndArgs (fs: FileUtils) testDir args projPath =
 
         fs.mkdir_p (testDir/"mocktool")
         copyDirFromAssets fs ``mock write args``.ProjDir (testDir/"mocktool")
         let falanxMock = testDir/"mocktool"/``mock write args``.FileName
         let falanxMockArgsPath = testDir/"mocktool"/"falanx-args.txt"
 
+        falanxMock |> replaceRealFalanxEnvVar (TestRunDirToolDir/"bin"/"falanx")
+
+        fs.rm_rf falanxMockArgsPath
+
         fs.cd testDir
 
-        dotnet fs ["build"; projPath; sprintf "/p:FalanxSdk_GeneratorExe=%s" falanxMock; "/p:FalanxSdk_GeneratorExeHost=" ]
-        |> ignore
-
-        Expect.isTrue (File.Exists falanxMockArgsPath) "mock should create a file who contains the args of invocation"
+        let cmd = dotnet fs (["build"; projPath; sprintf "/p:FalanxSdk_GeneratorExe=%s" falanxMock; "/p:FalanxSdk_GeneratorExeHost=" ] @ args)
 
         let lines =
-          File.ReadLines falanxMockArgsPath
-          |> List.ofSeq
+          if File.Exists falanxMockArgsPath then
+            File.ReadLines falanxMockArgsPath
+            |> List.ofSeq
+          else
+            []
 
-        lines
+        cmd, lines
+
+    let dotnetBuildWithFalanxArgsMock fs testDir projPath =
+      dotnetBuildWithFalanxArgsMockAndArgs fs testDir [] projPath
 
     testList "sdk integration" [
 
       testCase |> withLog "check invocation binary" (fun _ fs ->
         let testDir = inDir fs "sdkint_invocation_binary"
-        copyDirFromAssets fs ``template1 binary``.ProjDir testDir
+
+        testDir
+        |> copyExampleWithTemplate fs ``template1 binary`` ``sample6 bundle``
 
         let projPath = testDir/ (``template1 binary``.ProjectFile)
 
-        let lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+        let cmd, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
 
         let expected =
           [ "--inputfile"
             (testDir/``template1 binary``.ProtoFile)
             "--outputfile"
-            (testDir/"l1.Contracts"/"obj"/"Debug"/"netstandard2.0"/"l1.Contracts.FalanxSdk.g.fs")
+            sprintf "%s.fs" (testDir/``template1 binary``.ProtoFile)
             "--defaultnamespace"
             "l1.Contracts"
             "--serializer"
             "binary" ]
 
         Expect.equal lines expected "check invocation args"
+
+        cmd |> checkExitCodeZero
       )
 
       testCase |> withLog "check invocation json" (fun _ fs ->
         let testDir = inDir fs "sdkint_invocation_json"
-        copyDirFromAssets fs ``template2 json``.ProjDir testDir
+
+        testDir
+        |> copyExampleWithTemplate fs ``template2 json`` ``sample6 bundle``
 
         let projPath = testDir/ (``template2 json``.ProjectFile)
 
-        let lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+        let _, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
 
         let expected =
           [ "--inputfile"
             (testDir/``template2 json``.ProtoFile)
             "--outputfile"
-            (testDir/"l1.Contracts"/"obj"/"Debug"/"netstandard2.0"/"l1.Contracts.FalanxSdk.g.fs")
+            sprintf "%s.fs" (testDir/``template2 json``.ProtoFile)
             "--defaultnamespace"
             "l1.Contracts"
             "--serializer"
@@ -315,17 +334,19 @@ let tests pkgUnderTestVersion =
 
       testCase |> withLog "check invocation binary+json" (fun _ fs ->
         let testDir = inDir fs "sdkint_invocation_binaryjson"
-        copyDirFromAssets fs ``template3 binary+json``.ProjDir testDir
+
+        testDir
+        |> copyExampleWithTemplate fs ``template3 binary+json`` ``sample6 bundle``
 
         let projPath = testDir/ (``template3 binary+json``.ProjectFile)
 
-        let lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+        let _, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
 
         let expected =
           [ "--inputfile"
             (testDir/``template3 binary+json``.ProtoFile)
             "--outputfile"
-            (testDir/"l1.Contracts"/"obj"/"Debug"/"netstandard2.0"/"l1.Contracts.FalanxSdk.g.fs")
+            sprintf "%s.fs" (testDir/``template3 binary+json``.ProtoFile)
             "--defaultnamespace"
             "l1.Contracts"
             "--serializer"
@@ -334,6 +355,95 @@ let tests pkgUnderTestVersion =
             "binary" ]
 
         Expect.equal lines expected "check invocation args"
+      )
+
+      testCase |> withLog "check custom namespace" (fun _ fs ->
+        let testDir = inDir fs "sdkint_custom_namespace"
+
+        testDir
+        |> copyExampleWithTemplate fs ``template1 binary`` ``sample6 bundle``
+
+        let projPath = testDir/ (``template1 binary``.ProjectFile)
+
+        let ns = "abcd"
+
+        let _, lines = dotnetBuildWithFalanxArgsMockAndArgs fs testDir [sprintf "/p:RootNamespace=%s" ns] projPath
+
+        let expected =
+          [ "--inputfile"
+            (testDir/``template1 binary``.ProtoFile)
+            "--outputfile"
+            sprintf "%s.fs" (testDir/``template1 binary``.ProtoFile)
+            "--defaultnamespace"
+            ns
+            "--serializer"
+            "binary" ]
+
+        Expect.equal lines expected "check custom namespace"
+      )
+
+      testCase |> withLog "check no double generation" (fun _ fs ->
+        let testDir = inDir fs "sdkint_no_regen"
+
+        testDir
+        |> copyExampleWithTemplate fs ``template1 binary`` ``sample6 bundle``
+
+        let projPath = testDir/ (``template1 binary``.ProjectFile)
+
+        let cmd, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+
+        let expected =
+          [ "--inputfile"
+            (testDir/``template1 binary``.ProtoFile)
+            "--outputfile"
+            sprintf "%s.fs" (testDir/``template1 binary``.ProtoFile)
+            "--defaultnamespace"
+            "l1.Contracts"
+            "--serializer"
+            "binary" ]
+
+        Expect.equal lines expected "check invocation args"
+
+        cmd |> checkExitCodeZero
+
+        let cmd, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+
+        Expect.equal lines [] "check is not invoked the second time"
+
+        cmd |> checkExitCodeZero
+      )
+
+      testCase |> withLog "check regen if proto file is changed" (fun _ fs ->
+        let testDir = inDir fs "sdkint_proto_changed"
+
+        testDir
+        |> copyExampleWithTemplate fs ``template1 binary`` ``sample6 bundle``
+
+        let projPath = testDir/ (``template1 binary``.ProjectFile)
+
+        let cmd, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+
+        let expected =
+          [ "--inputfile"
+            (testDir/``template1 binary``.ProtoFile)
+            "--outputfile"
+            sprintf "%s.fs" (testDir/``template1 binary``.ProtoFile)
+            "--defaultnamespace"
+            "l1.Contracts"
+            "--serializer"
+            "binary" ]
+
+        Expect.equal lines expected "check invocation args"
+
+        cmd |> checkExitCodeZero
+
+        fs.touch (testDir/``template1 binary``.ProtoFile)
+
+        let cmd, lines = dotnetBuildWithFalanxArgsMock fs testDir projPath
+
+        Expect.equal lines expected "check is invoked the second time"
+
+        cmd |> checkExitCodeZero
       )
 
     ]

--- a/test/Falanx.Tests/Falanx.Tests.fsproj
+++ b/test/Falanx.Tests/Falanx.Tests.fsproj
@@ -25,28 +25,11 @@
     <FalanxSdk_GeneratorExeHost>dotnet </FalanxSdk_GeneratorExeHost>
     <FalanxSdk_GeneratorExe>..\..\Falanx.Tool\bin\$(Configuration)\netcoreapp2.1\falanx.dll</FalanxSdk_GeneratorExe>
   </PropertyGroup>
-  <!-- include to enable the generator for these formats -->
+  <!-- include to enable the generation of these formats -->
   <Import Project="..\..\Falanx.Proto.Codec.Binary\build\Falanx.Proto.Codec.Binary.props" />
   <Import Project="..\..\Falanx.Proto.Codec.Json\build\Falanx.Proto.Codec.Json.props" />
   <!-- do import directly the falanx sdk target, instead from package -->
-  <Target Name="FalanxSdkGenerateCode" BeforeTargets="BeforeCompile" Inputs="@(ProtoFile)" Outputs="%(Identity).fs">
-    <PropertyGroup>
-      <_FalanxOutPath>%(ProtoFile.OutputPath)</_FalanxOutPath>
-      <_FalanxOutPath Condition=" '$(_FalanxOutPath)' == '' ">%(ProtoFile.Identity).fs</_FalanxOutPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <FalanxSdk_CodeGenArgs Include="--inputfile &quot;%(ProtoFile.Identity)&quot;" />
-      <FalanxSdk_CodeGenArgs Include="--outputfile &quot;$(_FalanxOutPath)&quot;" />
-      <FalanxSdk_CodeGenArgs Include="--defaultnamespace &quot;$(RootNamespace)&quot;" />
-      <FalanxSdk_CodeGenArgs Include="--serializer %(FalanxSdkSerializer.Identity)" />
-    </ItemGroup>
-    <!-- Use dotnet to execute the process. -->
-    <Exec Command="$(FalanxSdk_GeneratorExeHost)&quot;$(FalanxSdk_GeneratorExe)&quot; @(FalanxSdk_CodeGenArgs -&gt; '%(Identity)', ' ')"
-          WorkingDirectory="$(MSBuildThisFileDirectory)" />
-    <ItemGroup>
-      <CompileBefore Include="$(_FalanxOutPath)" />
-      <FileWrites Include="$(_FalanxOutPath)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="..\..\Falanx.Sdk\build\Falanx.Sdk.targets" />
+  <!-- paket -->
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/test/examples/mock1/falanx-mock
+++ b/test/examples/mock1/falanx-mock
@@ -9,3 +9,5 @@ for ARG in "$@"
 do
     echo $ARG >> $SCRIPT_DIR/falanx-args.txt
 done
+
+"$REAL_FALANX" $@

--- a/test/examples/mock1/falanx-mock.bat
+++ b/test/examples/mock1/falanx-mock.bat
@@ -5,3 +5,5 @@ del %~dp0\falanx-args.txt
 for %%x in (%*) do (
    echo %%~x>> %~dp0\falanx-args.txt
 )
+
+"%REAL_FALANX%" %*


### PR DESCRIPTION
- remove unused props
- allow multiple proto
- generated .fs files, by default, are alongside the .proto files
- use `OutputPath` metadata of `ProtoFile` item to specify generated .fs file path
- compile files are included at beginning of the compile list (allow use in console app)
- not yet implemented the clean process

add integration tests:

- custom namespace
- no generation on build if proto is unchanged
- the .fs file is regenerated on build if proto file is changed