### PR TITLE
Upgrade source link to fix build on debian linuxes. Fix #71

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,6 @@
     <NupkgsDir>$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)/artifact/nupkg"))</NupkgsDir>
     <MonoOrEmpty Condition=" '$(OS)' != 'Windows_NT' ">mono </MonoOrEmpty>
 
-    <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-
     <Version Condition=" '$(Version)' == '' ">0.4.0-alpha3$(VersionSuffix)</Version>
 
     <NoWarn>$(NoWarn);FS2003</NoWarn>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,7 +13,7 @@ nuget Froto.Serialization
 nuget Fleece.NewtonsoftJson 0.8.0-alpha-2
 nuget Newtonsoft.Json 11.0.2
 
-nuget Microsoft.SourceLink.GitHub copy_local: true
+nuget Microsoft.SourceLink.GitHub 1.0.0-beta2-18618-05 copy_local: true
 
 github 7sharp9/FSharp.TypeProviders.SDK:generator src/ProvidedTypes.fs 
 github 7sharp9/FSharp.TypeProviders.SDK:generator src/ProvidedTypesTesting.fs 

--- a/paket.lock
+++ b/paket.lock
@@ -35,13 +35,13 @@ NUGET
     FSharp.Core (4.5.4)
     FSharpPlus (1.1.0-CI00252)
       FSharp.Core (>= 4.3.4)
-    Microsoft.Build.Tasks.Git (1.0.0-beta-63127-02) - copy_local: true
+    Microsoft.Build.Tasks.Git (1.0.0-beta2-18618-05) - copy_local: true
     Microsoft.NETCore.Platforms (2.1.1)
     Microsoft.NETCore.Targets (2.1)
-    Microsoft.SourceLink.Common (1.0.0-beta-63127-02) - copy_local: true
-    Microsoft.SourceLink.GitHub (1.0.0-beta-63127-02) - copy_local: true
-      Microsoft.Build.Tasks.Git (>= 1.0.0-beta-63127-02)
-      Microsoft.SourceLink.Common (>= 1.0.0-beta-63127-02)
+    Microsoft.SourceLink.Common (1.0.0-beta2-18618-05) - copy_local: true
+    Microsoft.SourceLink.GitHub (1.0.0-beta2-18618-05) - copy_local: true
+      Microsoft.Build.Tasks.Git (>= 1.0.0-beta2-18618-05)
+      Microsoft.SourceLink.Common (>= 1.0.0-beta2-18618-05)
     Microsoft.Win32.Primitives (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)


### PR DESCRIPTION
Root cause: https://github.com/dotnet/sourcelink/issues/155
With this patch I can successfully compile on ubuntu 18.10
cc: @enricosada 