### PR TITLE
make the namespace command line argument as optional

### DIFF
--- a/Falanx.Tool/Program.fs
+++ b/Falanx.Tool/Program.fs
@@ -21,13 +21,13 @@ module main =
                 | DefaultNamespace _ -> "specify a default namespace to use for code generation."
                 | OutputFile _ -> "Specify the file name that the generated code will be written to."
                 | Serializer _ -> "serialization format. default binary"
-
-    
-    let parser = ArgumentParser.Create<Arguments>(programName = "falanx")
     
     [<EntryPoint>]
     let main argv =
+        let parser = ArgumentParser.Create<Arguments>(programName = "falanx")
+
         try
+
             let results = parser.Parse argv
             let inputFile = results.GetResult InputFile
             let outputFile = results.GetResult OutputFile
@@ -39,11 +39,14 @@ module main =
             let protoDef = IO.File.ReadAllText inputFile
             printfn "Generating code for: %s" inputFile
             Proto.createFSharpDefinitions(protoDef, outputFile, defaultNamespace, codecs)
+            0
         with
         | :? FileNotFoundException as fnf ->
             printfn "ERROR: inputfile %s doesn not exist\n%s" fnf.FileName (parser.PrintUsage())
+            2
         | :? FormatException as fex when fex.Source = "Froto.Parser" ->
             printfn "ERROR: proto file was not able to be parsed.\n\n%s" fex.Message
-        | ex -> printfn "%s\n%s" (parser.PrintUsage()) ex.Message
-    
-        0 // return an integer exit code
+            3
+        | ex ->
+            printfn "%s\n%s" (parser.PrintUsage()) ex.Message
+            1

--- a/Falanx.Tool/Program.fs
+++ b/Falanx.Tool/Program.fs
@@ -20,7 +20,7 @@ module main =
                 | DefaultNamespace _ -> "specify a default namespace to use for code generation."
                 | OutputFile _ -> "Specify the file name that the generated code will be written to."
                 | Serializer _ -> "serialization format. default binary"
-    
+
     [<EntryPoint>]
     let main argv =
         let parser = ArgumentParser.Create<Arguments>(programName = "falanx")
@@ -40,12 +40,20 @@ module main =
             Proto.createFSharpDefinitions(protoDef, outputFile, defaultNamespace, codecs)
             0
         with
+        | :? ArguParseException as ae ->
+            printfn "%s" ae.Message
+            match ae.ErrorCode with
+            | Argu.ErrorCode.HelpText -> 0
+            | _ -> 2
+        | :? ArguParseException as ae when ae.ErrorCode = Argu.ErrorCode.HelpText ->
+            printfn "%s" ae.Message
+            3
         | :? FileNotFoundException as fnf ->
             printfn "ERROR: inputfile %s doesn not exist\n%s" fnf.FileName (parser.PrintUsage())
-            2
+            4
         | :? FormatException as fex when fex.Source = "Froto.Parser" ->
             printfn "ERROR: proto file was not able to be parsed.\n\n%s" fex.Message
-            3
+            5
         | ex ->
             printfn "%s\n%s" (parser.PrintUsage()) ex.Message
             1

--- a/Falanx.Tool/Program.fs
+++ b/Falanx.Tool/Program.fs
@@ -9,7 +9,7 @@ module main =
 
     type Arguments =
         | [<Mandatory>] InputFile of string
-        | [<Mandatory>] DefaultNamespace of string
+        | DefaultNamespace of string
         | [<Mandatory>] OutputFile of string
         | Serializer of Codec
     with
@@ -30,7 +30,10 @@ module main =
             let results = parser.Parse argv
             let inputFile = results.GetResult InputFile
             let outputFile = results.GetResult OutputFile
-            let defaultNamespace = results.GetResult DefaultNamespace
+            let defaultNamespace =
+                match results.TryGetResult DefaultNamespace with
+                | Some ns -> ns
+                | None -> Path.GetFileNameWithoutExtension(inputFile)
             let codecs =
                 match results.GetResults Serializer with
                 | [] -> Set.singleton Binary

--- a/Falanx.Tool/Program.fs
+++ b/Falanx.Tool/Program.fs
@@ -4,7 +4,6 @@ open System.IO
 open Argu
 open Falanx.Proto.Generator
 open Falanx.Proto.Generator.TypeGeneration
-open Falanx.Proto.Codec.Json
 
 module main =
 


### PR DESCRIPTION
if the arg `--defaultnamespace` is not specified, the proto filename will be used as namespace

fix #74

cleanup exit codes (`--help` has exit code zero, others failures has non zero)