### PR TITLE
add template package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "paket-files",
         "test/testrun",
         "test/examples",
+        "Falanx.Templates/ClassLibrary-FSharp",
         "packages"
     ]
 }

--- a/Falanx.Sdk/build/Falanx.Sdk.targets
+++ b/Falanx.Sdk/build/Falanx.Sdk.targets
@@ -78,7 +78,7 @@
           BeforeTargets="CoreCompile"
           Condition=" '$(DesignTimeBuild)' == 'true' ">
     <ItemGroup>
-      <Compile Include="%(ProtoFileCodegen.OutputPath)" />
+      <CompileBefore Include="%(ProtoFileCodegen.OutputPath)" />
     </ItemGroup>
   </Target>
 

--- a/Falanx.Templates/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
+++ b/Falanx.Templates/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "FalanxCodecFormat": {
+      "longName": "codec",
+      "shortName": ""
+    },
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": [
+    "--codec all",
+    "--codec json",
+    "--codec binary"
+  ]
+}

--- a/Falanx.Templates/ClassLibrary-FSharp/.template.config/template.json
+++ b/Falanx.Templates/ClassLibrary-FSharp/.template.config/template.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "JET.com",
+  "classifications": ["Common", "Library", "Protobuff"],
+  "name": "Falanx library",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A example project for creating a library that use Falanx to serialize protobuff",
+  "groupIdentity": "Jet.Falanx",
+  "precedence": "3000",
+  "identity": "Jet.Falanx.FSharp.2.1",
+  "shortName": "falanx",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.ClassLibrary1",
+  "preferNameDirectory": true,
+  "baselines": {
+    "app": {
+      "description": "Target netcoreapp",
+      "defaultOverrides": {
+        "Framework": "netcoreapp2.1"
+      }
+    },
+    "standard": {
+      "description": "Target netstandard",
+      "defaultOverrides": {
+        "Framework": "netstandard2.0"
+      }
+    }
+  },
+  "symbols": {
+    "FalanxVersion": {
+      "type": "parameter",
+      "description": "Overrides the falanx version",
+      "replaces": "$(FalanxVersion)",
+      "datatype": "string",
+      "defaultValue": "0.4.0-alpha3"
+    },
+    "FalanxCodecFormat":{
+      "type":"parameter",
+      "datatype": "choice",
+      "defaultValue":"all",
+      "choices": [
+        {
+          "choice": "json",
+          "description": "Json serialization"
+        },
+        {
+          "choice": "binary",
+          "description": "Binary serialization"
+        },
+        {
+          "choice": "all",
+          "description": "Both Json and Binary serialization"
+        }
+      ],
+      "replaces": "FalanxCodecFormat"
+    },
+    "FalanxJsonCodec":{
+      "type": "computed",
+      "value": "(FalanxCodecFormat == \"all\" || FalanxCodecFormat == \"json\")"
+    },
+    "FalanxBinaryCodec":{
+      "type": "computed",
+      "value": "(FalanxCodecFormat == \"all\" || FalanxCodecFormat == \"binary\")"
+    },
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
+          "choice": "netstandard2.0",
+          "description": "Target netstandard2.0"
+        }
+      ],
+      "replaces": "netstandard2.0",
+      "defaultValue": "netstandard2.0"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    { "path": "Company.ClassLibrary1.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Library.fs"
+    }
+  ],
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!FalanxJsonCodec)",
+          "exclude": [
+            "JsonSerializerExample.fs"
+          ]
+        },
+        {
+          "condition": "(!FalanxBinaryCodec)",
+          "exclude": [
+            "BinarySerializerExample.fs"
+          ]
+        }
+      ]
+    }
+  ],
+  "defaultName": "ClassLibrary1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens Library.fs in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/Falanx.Templates/ClassLibrary-FSharp/BinarySerializerExample.fs
+++ b/Falanx.Templates/ClassLibrary-FSharp/BinarySerializerExample.fs
@@ -1,0 +1,18 @@
+﻿namespace Company.ClassLibrary1
+
+module BinarySerializerExample =
+
+    let serialize () =
+        let r =
+            { BundleRequest.martId = Some 1
+              memberId =  Some "myId"
+              channelType = None
+              retailSkus = Some "sdk-1" }
+
+        let buffer = new Froto.Serialization.ZeroCopyBuffer(1000)
+        BundleRequest.Serialize(r, buffer)
+        buffer.ToArray()
+
+    let deserialize (bytes: byte array) =
+        let buffer = new Froto.Serialization.ZeroCopyBuffer(bytes)
+        BundleRequest.Deserialize(buffer)

--- a/Falanx.Templates/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
+++ b/Falanx.Templates/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProtoFile Include="bundle.proto" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Condition=" '$(FalanxJsonCodec)' == 'true' " Include="JsonSerializerExample.fs" />
+    <Compile Condition=" '$(FalanxBinaryCodec)' == 'true' " Include="BinarySerializerExample.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Condition=" '$(FalanxJsonCodec)' == 'true' " Include="Falanx.Proto.Codec.Json" Version="$(FalanxVersion)" />
+    <PackageReference Condition=" '$(FalanxBinaryCodec)' == 'true' " Include="Falanx.Proto.Codec.Binary" Version="$(FalanxVersion)" />
+    <PackageReference Include="Falanx.Sdk" Version="$(FalanxVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/Falanx.Templates/ClassLibrary-FSharp/JsonSerializerExample.fs
+++ b/Falanx.Templates/ClassLibrary-FSharp/JsonSerializerExample.fs
@@ -1,0 +1,17 @@
+﻿namespace Company.ClassLibrary1
+
+module JsonSerializerExample =
+
+    open Fleece.Newtonsoft
+
+    let serialize () : string =
+        let r =
+            { BundleRequest.martId = Some 1
+              memberId =  Some "myId"
+              channelType = None
+              retailSkus = Some "sdk-1" }
+
+        toJson r |> string
+
+    let deserialize (jsonText: string) =
+        parseJson<BundleRequest> jsonText

--- a/Falanx.Templates/ClassLibrary-FSharp/bundle.proto
+++ b/Falanx.Templates/ClassLibrary-FSharp/bundle.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message BundleRequest {
+  int32 martId = 1;
+  string member_id = 2;
+  string channel_type = 3;
+  string retail_skus = 4;
+}

--- a/Falanx.Templates/Falanx.Templates.proj
+++ b/Falanx.Templates/Falanx.Templates.proj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
+    <NoBuild>true</NoBuild>
+
+    <PackageId>Falanx.Templates</PackageId>
+
+    <PackageType>Template</PackageType>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <Content Include="ClassLibrary-FSharp\**\*" Exclude="ClassLibrary-FSharp\bin\**;ClassLibrary-FSharp\obj\**">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/build.proj
+++ b/build.proj
@@ -19,6 +19,7 @@
     <Exec Command='dotnet pack Falanx.Proto.Core -c Release -o "$(NupkgsDir)" /p:Version=$(Version)' />
     <Exec Command='dotnet pack Falanx.Sdk -c Release -o "$(NupkgsDir)" /p:Version=$(Version)' />
     <Exec Command='dotnet pack Falanx.Tool -c Release -o "$(NupkgsDir)" /p:Version=$(Version)' />
+    <Exec Command='dotnet pack Falanx.Templates -c Release -o "$(NupkgsDir)" /p:Version=$(Version)' />
     <Exec Command='dotnet mergenupkg --source "$(NupkgsDir)/Falanx.Sdk.$(Version).nupkg" --other "$(NupkgsDir)/Falanx.Tool.$(Version).nupkg" --tools --only-files' WorkingDirectory="tools" />
   </Target>
 

--- a/test/Falanx.IntegrationTests/Sample.fs
+++ b/test/Falanx.IntegrationTests/Sample.fs
@@ -797,9 +797,82 @@ let tests pkgUnderTestVersion =
 
     ]
 
+  let template =
+
+    let uninstallTemplate fs =
+      dotnetCmd fs ["new"; "-u"; "Falanx.Templates" ]
+
+    let installTemplate fs =
+      dotnetCmd fs ["new"; "--nuget-source"; NupkgsDir; "-i"; sprintf "Falanx.Templates::%s" pkgUnderTestVersion ]
+
+    let withTemplate fs =
+      // uninstall if installed
+      uninstallTemplate fs |> ignore
+
+      installTemplate fs
+      |> checkExitCodeZero
+
+      { new IDisposable with
+          member __.Dispose() =
+            // uninstall if installed
+            uninstallTemplate fs |> ignore
+      }
+
+    testList "template" [
+
+      testCase |> withLog "codec all" (fun _ fs ->
+        let testDir = inDir fs "template_codec_all"
+
+        use _template = withTemplate fs
+
+        dotnetCmd fs ["new"; "falanx"; "--codec"; "all" ]
+        |> checkExitCodeZero
+
+        dotnet fs ["build" ]
+        |> checkExitCodeZero
+      )
+
+      testCase |> withLog "codec binary" (fun _ fs ->
+        let testDir = inDir fs "template_codec_binary"
+
+        use _template = withTemplate fs
+
+        dotnetCmd fs ["new"; "falanx"; "--codec"; "binary" ]
+        |> checkExitCodeZero
+
+        dotnet fs ["build" ]
+        |> checkExitCodeZero
+      )
+
+      testCase |> withLog "codec json" (fun _ fs ->
+        let testDir = inDir fs "template_codec_json"
+
+        use _template = withTemplate fs
+
+        dotnetCmd fs ["new"; "falanx"; "--codec"; "json" ]
+        |> checkExitCodeZero
+
+        dotnet fs ["build" ]
+        |> checkExitCodeZero
+      )
+
+      testCase |> withLog "default codec" (fun _ fs ->
+        let testDir = inDir fs "template_codec_default"
+
+        use _template = withTemplate fs
+
+        dotnetCmd fs ["new"; "falanx" ]
+        |> checkExitCodeZero
+
+        dotnet fs ["build" ]
+        |> checkExitCodeZero
+      )
+    ]
+
   [ generalTests
     sanityChecks
     sdkIntegrationMocks
+    template
     interop ]
   |> testList "suite"
   |> testSequenced


### PR DESCRIPTION
add `Falanx.Templates` template package, with a library example

Support `--codec` command line argument.
valid values: `json`, `binary`, `all`. Default `all`.

Examples

```
dotnet new falanx
dotnet new falanx --codec json
```

fix #31 

TODO

- [x] remove hardcoded version, move to build infra
- [x] fix invalid `#endif` with `--codec binary`
- [x] add integration tests

NEXT

- [ ] add option to specify the `.proto` file path
- [ ] add option to specify `.fs` file, to show to use `OutputPath`

