### PR TITLE
compile error using repeated field

### DIFF
--- a/test/Falanx.Tests/schemas/falanx_test.proto
+++ b/test/Falanx.Tests/schemas/falanx_test.proto
@@ -110,7 +110,7 @@ message TestAllTypes {
   repeated     bool repeated_bool     = 43;
   repeated   string repeated_string   = 44;
   */
-  //repeated    bytes repeated_bytes    = 45;
+  repeated    bytes repeated_bytes    = 45;
 
   //repeated NestedMessage                        repeated_nested_message  = 48;
   //repeated ForeignMessage                       repeated_foreign_message = 49;

--- a/test/Falanx.Tests/schemas/falanx_test.proto
+++ b/test/Falanx.Tests/schemas/falanx_test.proto
@@ -108,9 +108,9 @@ message TestAllTypes {
   repeated    float repeated_float    = 41;
   repeated   double repeated_double   = 42;
   repeated     bool repeated_bool     = 43;
-  repeated   string repeated_string   = 44;
   */
-  repeated    bytes repeated_bytes    = 45;
+  repeated   string repeated_string   = 44;
+//  repeated    bytes repeated_bytes    = 45;
 
   //repeated NestedMessage                        repeated_nested_message  = 48;
   //repeated ForeignMessage                       repeated_foreign_message = 49;


### PR DESCRIPTION
@7sharp9 i get this error using a `repeated` field

```
test\Falanx.Tests\schemas\falanx_test.proto.fs(45,50): error FS0039: The value, constructor, namespace or type 'Json' is not defined. [E:\github\jet\falanx\test\Falanx.Tests\Falanx.Tests.fsproj]
test\Falanx.Tests\schemas\falanx_test.proto.fs(59,59): error FS0001: Type mismatch. Expecting a    'Decoder<IReadOnlyDictionary<string,JsonValue>,(Int32 option -> Option<Int64> -> Option<UInt32> -> Option<UInt64> -> Option<Int32> -> Option<Int64> -> Option<UInt32> -> Option<UInt64> -> Option<Int32> -> Option<Int64> -> Option<Single> -> Option<Double> -> Option<Boolean> -> Option<String> -> List<ArraySegment<Byte>> -> TestAllTypes)>'    but given a    'IReadOnlyDictionary<string,JsonValue> -> Result<(Option<Int32> -> Option<Int64> -> Option<UInt32> -> Option<UInt64> -> Option<Int32> -> Option<Int64> -> Option<UInt32> -> Option<UInt64> -> Option<Int32> -> Option<Int64> -> Option<Single> -> Option<Double> -> Option<Boolean> -> Option<String> -> Option<List<ArraySegment<Byte>>> -> TestAllTypes),DecodeError>'    The type 'List<ArraySegment<Byte>>' does not match the type 'Option<List<ArraySegment<Byte>>>' [E:\github\jet\falanx\test\Falanx.Tests\Falanx.Tests.fsproj]
test\Falanx.Tests\schemas\falanx_test.proto.fs(212,13): error FS0001: No overloads match for method 'ToJson'. The available overloads are shown below. [E:\github\jet\falanx\test\Falanx.Tests\Falanx.Tests.fsproj]
test\Falanx.Tests\Compatibility.fs(20,37): error FS0193: No overloads match for method 'OfJson'. The available overloads are shown below. [E:\github\jet\falanx\test\Falanx.Tests\Falanx.Tests.fsproj]
```