### PR TITLE
regenerate files if the falanx tool is changed

### DIFF
--- a/src/Falanx.Sdk/build/Falanx.Sdk.targets
+++ b/src/Falanx.Sdk/build/Falanx.Sdk.targets
@@ -28,7 +28,7 @@
           BeforeTargets="FalanxSdkGenerateCode">
 
     <ItemGroup>
-      <FalanxSdk_CodeGenInputs Include="@(ProtoFileCodegen);@(ReferencePath)" />
+      <FalanxSdk_CodeGenInputs Include="@(ProtoFileCodegen);@(ReferencePath);$(FalanxSdk_GeneratorExe)" />
     </ItemGroup>
 
     <Hash ItemsToHash="@(FalanxSdk_CodeGenInputs)">
@@ -51,7 +51,7 @@
           DependsOnTargets="$(FalanxSdkGenerateCodeDependsOn)"
           BeforeTargets="CoreCompile"
           Condition=" '$(DesignTimeBuild)' != 'true' "
-          Inputs="@(ProtoFileCodegen);$(_FalanxSdkCodeGenInputCache)"
+          Inputs="@(ProtoFileCodegen);$(_FalanxSdkCodeGenInputCache);$(FalanxSdk_GeneratorExe)"
           Outputs="%(ProtoFileCodegen.OutputPath)">
 
     <PropertyGroup>


### PR DESCRIPTION
@7sharp9 this make testing easier, so after the `Falanx.Tool` is rebuilt,
a new `dotnet build` of `Falanx.Tests` will regenerate the proto file (also when unchanged)