### PR TITLE
Fixing command in README so that it works in current directory.

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -21,5 +21,5 @@ tools/falanx --help
 ## sample1
 
 ```
-falanx --inputfile ../sample1/bundle.proto --defaultnamespace MyNamespace --outputfile bundle.fs
+falanx --inputfile ./sample1/bundle.proto --defaultnamespace MyNamespace --outputfile bundle.fs
 ```


### PR DESCRIPTION
If you're in the same directory as the README and execute the given falanx command, it will complain about not being able to find the file.  I've changed the command to assume you're in the same directory as the README.